### PR TITLE
Zip all files in dist folder

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,6 @@ jobs:
     - name: Extract release notes from CHANGELOG.md
       id: extract_release_notes
       run: |
-        VERSION=${{steps.get_version.outputs.version-without-v}}
         RELEASE_NOTES=$(awk "/^# [0-9]+\.[0-9]+\.[0-9]+/{if (p) exit; p=1; next} p" CHANGELOG.md)
         echo "::set-output name=notes::$RELEASE_NOTES"
         

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Create zip archive
       working-directory: dist
-      run: zip -r ./module.zip module.json style.css style.css.map scripts/ templates/ lang/
+      run: zip -r ./module.zip *
     
     - name: Install jq and yq
       run: |


### PR DESCRIPTION
Rather than zip a specific selection of files, just grab the entire output of the vite build and zip it up.

I don't know why I didn't check the zip step before submitting, but this will resolve the issue with the js and css not getting zipped in the build.
